### PR TITLE
Fix jack

### DIFF
--- a/net.biniou.LeBiniou.yml
+++ b/net.biniou.LeBiniou.yml
@@ -64,6 +64,8 @@ modules:
       - --sndfile=no
       - --readline=no
       - --db=no
+    cleanup:
+      - '*'
     sources:
       - type: archive
         url: https://github.com/jackaudio/jack2/archive/v1.9.16.tar.gz


### PR DESCRIPTION
With this jack support work.

tl;dr: remove jack completely and pipewire jack libraries will be used. Jack itself will never work through the sandbox.