### PR TITLE
Update to 22.08 runtime

### DIFF
--- a/net.biniou.LeBiniou.yml
+++ b/net.biniou.LeBiniou.yml
@@ -1,6 +1,6 @@
 app-id: net.biniou.LeBiniou
 runtime: org.freedesktop.Platform
-runtime-version: '21.08'
+runtime-version: '22.08'
 sdk: org.freedesktop.Sdk
 command: lebiniou
 finish-args:
@@ -21,9 +21,9 @@ cleanup:
   - /include
   - /lib/pkgconfig
 sdk-extensions:
-  - org.freedesktop.Sdk.Extension.node14
+  - org.freedesktop.Sdk.Extension.node16
 build-options:
-  append-path: /usr/lib/sdk/node14/bin
+  append-path: /usr/lib/sdk/node16/bin
 modules:
   - name: microhttpd
     buildsystem: autotools
@@ -54,27 +54,6 @@ modules:
       - type: archive
         url: https://github.com/ImageMagick/ImageMagick6/archive/6.9.11-51.tar.gz
         sha256: 06c4363486e1053e69bb3fa211374bdaed4baa678ca8ccd1f38731f0da2d3497
-  - name: jackaudio
-    buildsystem: simple
-    config-opts:
-      - --iio=no
-      - --portaudio=no
-      - --winmme=no
-      - --celt=no
-      - --opus=no
-      - --samplerate=no
-      - --sndfile=no
-      - --readline=no
-      - --db=no
-    cleanup:
-      - '*'
-    sources:
-      - type: archive
-        url: https://github.com/jackaudio/jack2/archive/v1.9.16.tar.gz
-        sha256: e176d04de94dcaa3f9d32ca1825091e1b938783a78c84e7466abd06af7637d37
-    build-commands:
-      - ./waf configure --prefix=$FLATPAK_DEST
-      - ./waf install
   - name: orcania
     buildsystem: cmake-ninja
     sources:


### PR DESCRIPTION
- remove jack (the headers are now in the SDK)
- Update node to Node 16.